### PR TITLE
Check links for errors, add a new tag to processed links, and max # articles

### DIFF
--- a/Pinboard.recipe
+++ b/Pinboard.recipe
@@ -16,6 +16,18 @@ apitoken = ''
 #
 delete_bookmarks = False
 
+
+#
+# How many articles to pull at most? Set to False for no checks.
+#
+max_articles = 15
+
+#
+# Should processed articles receive a tag? If so, set the tag:
+#
+processed_tag = 'calibre-recipe'
+
+
 from calibre.web.feeds.news import BasicNewsRecipe
 import urllib
 import json
@@ -42,25 +54,39 @@ class PinboardRecipe(BasicNewsRecipe):
 		
 		if len(bookmarks) == 0:
 			self.abort_recipe_processing('No unread Pinboard bookmarks.')
-		
+
+                successful_bookmark_reads = 0
 		articles = []
 		for bookmark in bookmarks:
-			articles.append({
+                        try:
+                                urllib.urlopen(bookmark['href'])
+
+                                articles.append({
 					'title': bookmark['description'],
 					'url': bookmark['href'],
 					'description': bookmark['extended'],
 					'date': bookmark['time']})
 			
-			if delete_bookmarks:
-				params = urllib.urlencode({'url': bookmark['href'], 'auth_token': apitoken})
-				urllib.urlopen('https://api.pinboard.in/v1/posts/delete?' + params)
-			else:
-				# Mark bookmark as read by re-posting with 'toread' set to 'no'.
-				params = urllib.urlencode({
+                                if delete_bookmarks:
+                                        params = urllib.urlencode({'url': bookmark['href'], 'auth_token': apitoken})
+                                        urllib.request.urlopen('https://api.pinboard.in/v1/posts/delete?' + params)
+                                else:
+                                        if processed_tag:
+                                                bookmark['tags'] += ' {}'.format(processed_tag)
+
+                                        # Mark bookmark as read by re-posting with 'toread' set to 'no'.
+                                        params = urllib.urlencode({
 						'url': bookmark['href'], 'description': bookmark['description'],
 						'extended': bookmark['extended'], 'tags': bookmark['tags'],
 						'dt': bookmark['time'], 'shared': bookmark['shared'],
 						'replace': 'yes', 'toread': 'no', 'auth_token': apitoken})
-				urllib.urlopen('https://api.pinboard.in/v1/posts/add?' + params)
+                                        urllib.urlopen('https://api.pinboard.in/v1/posts/add?' + params)
+
+                                successful_bookmark_reads += 1
+                                if max_articles and successful_bookmark_reads >= max_articles:
+                                        break
+
+                        except IOError:
+                                continue
 				
 		return [('Pinboard Bookmarks', articles)]

--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,8 @@ Setup
 - In Calibre, select _Add a custom news source_ from the _Fetch news_ toolbar button or menu. Click _Load recipe from file_ and select the [`Pinboard.recipe`](https://raw.github.com/anoved/Pinboard-Recipe/master/Pinboard.recipe) file downloaded from this repository.
 - Locate your [Pinboard API Token](https://pinboard.in/settings/password) and paste it into the _Pinboard Bookmarks_ source code as the `apitoken` value (indicated near the top of the script).
 - By default, your unread bookmarks are marked as read once retrieved. If you would prefer to delete them instead, set the `delete_bookmarks` variable to `True`.
+- By default, 15 links will be pulled per run. To pull all links, set the `max_articles` variable to `False`.
+- By default, any links processed will receive a new tag, `calibre-recipe`. To change or remove this tag, set the `processed_tag` variable to False or a different string.
 - Click _Add/Update recipe_ and click _Yes_ to confirm that you want to update ("replace") the recipe.
 
 Now when you click _Fetch News_ you can choose _Pinboard Bookmarks_ from the _Custom_ section of the recipe list.


### PR DESCRIPTION
Thanks for writing Pinboard-Recipe! It's great!

I have a backlog of like 5 years' worth of links that are marked `toread`, and the recipe was overwhelmed by the number as well as some of the links, which were no longer available and made Calibre error out after `toread` had already been unset.

This code tests the links before sending them to Calibre, and also adds options to pull only a certain number of links and to add a new tag so that you can find the links you've processed.
